### PR TITLE
Ensure `pipermail.stringify()` output is ASCII-only

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -1,11 +1,12 @@
 var Transform = require('barrage').Transform
+var jsesc = require('jsesc')
 
 module.exports = stringify;
 function stringify() {
   var stream = new Transform({objectMode: true})
   var first = true
   stream._transform = function (item, _, cb) {
-    stream.push((first ? '' : '\n') + JSON.stringify(item))
+    stream.push((first ? '' : '\n') + jsesc(item, {json: true}))
     first = false
     cb()
   }

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "description": "node.js utilities for reading pipermail archives such as es-discuss",
   "main": "index.js",
   "dependencies": {
-    "request": "~2.22.0",
-    "htmlparser2": "~3.1.4",
+    "barrage": "0.0.4",
     "ent": "https://github.com/esdiscuss/ent/archive/fixed.tar.gz",
+    "htmlparser2": "~3.1.4",
+    "jsesc": "~0.4.1",
     "promise": "~3.2.0",
-    "barrage": "0.0.4"
+    "request": "~2.22.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
For example, instead of this:

```
{"email":"bar@example.com","name":"Olav Junker Kjær"}
```

…`pipermail.stringify()` now returns:

```
{"email":"bar@example.com","name":"Olav Junker Kj\u00E6r"}
```

…which is more portable.
